### PR TITLE
Replace Ktor and reduce minSDK version to 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ AirwallexRisk.log(
 
 When your app sends a request to Airwallex, you must add the provided header into your request before sending. This will be slightly different depending on your networking library, so check the documentation describing how to add headers for the library you're using.
 
-Some networking libraries you may be using 
+Some networking libraries you may be using
 - [Ktor](https://ktor.io/docs/request.html#parameters)
 - [OkHttp](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-request/-builder/add-header)
 

--- a/RiskSdk/build.gradle
+++ b/RiskSdk/build.gradle
@@ -8,11 +8,11 @@ apply from: "$rootProject.projectDir/jacoco.gradle"
 
 android {
     namespace 'com.airwallex.risk'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
-        minSdk 26
-        targetSdk 33
+        minSdk 21
+        targetSdkVersion 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -36,28 +36,22 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.core:core-ktx:1.13.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1'
-    implementation 'androidx.lifecycle:lifecycle-process:2.6.1'
-    implementation 'androidx.lifecycle:lifecycle-common:2.6.1'
-    implementation 'androidx.core:core-ktx:1.10.1'
-
-    def ktorVersion = "2.3.2"
-    implementation "io.ktor:ktor-client-android:$ktorVersion"
-    implementation "io.ktor:ktor-client-cio:$ktorVersion"
-    implementation "io.ktor:ktor-client-content-negotiation:$ktorVersion"
-    implementation "io.ktor:ktor-serialization-kotlinx-json:$ktorVersion"
+    implementation 'androidx.lifecycle:lifecycle-process:2.8.3'
+    implementation 'androidx.lifecycle:lifecycle-common:2.8.3'
+    implementation 'androidx.core:core-ktx:1.13.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'io.mockk:mockk:1.13.3'
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
-    testImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.6.1'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test:1.7.20'
+    testImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.8.3'
+    testImplementation 'org.jetbrains.kotlin:kotlin-test:1.8.0'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }
 
 nexusPublishing {

--- a/RiskSdk/src/main/java/com/airwallex/risk/BuildHelper.kt
+++ b/RiskSdk/src/main/java/com/airwallex/risk/BuildHelper.kt
@@ -14,4 +14,7 @@ internal object BuildHelper {
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
     fun isVersionAtLeastTiramisu() = sdkVersion >= Build.VERSION_CODES.TIRAMISU
+
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.N)
+    fun isVersionAtLeastN() = sdkVersion >= Build.VERSION_CODES.N
 }

--- a/RiskSdk/src/main/java/com/airwallex/risk/DataCollector.kt
+++ b/RiskSdk/src/main/java/com/airwallex/risk/DataCollector.kt
@@ -26,7 +26,12 @@ internal interface IDataCollector {
 
 internal class DataCollector(
     applicationContext: Context,
-    private val systemLocale: Locale = Resources.getSystem().configuration.locales[0],
+    private val systemLocale: Locale = if (BuildHelper.isVersionAtLeastN()) {
+        Resources.getSystem().configuration.locales[0]
+    } else {
+        @Suppress("DEPRECATION")
+        Resources.getSystem().configuration.locale
+    },
     private val appLocale: Locale = Locale.getDefault()
 ) : IDataCollector {
     // region Private

--- a/RiskSdk/src/main/java/com/airwallex/risk/Event.kt
+++ b/RiskSdk/src/main/java/com/airwallex/risk/Event.kt
@@ -24,7 +24,7 @@ internal data class Event(
         dataCollector: IDataCollector,
         eventType: String,
         path: String?,
-        createdAtUtc: Instant
+        createdAtUtc: Long
     ) : this(
         eventId = UUID.randomUUID(),
         accountId = riskContext.accountId,
@@ -37,7 +37,7 @@ internal data class Event(
         event = EventDetails(
             type = eventType,
             screen = Screen(path = path),
-            createdAtUtc = createdAtUtc.toEpochMilli()
+            createdAtUtc = createdAtUtc
         )
     )
 }

--- a/RiskSdk/src/main/java/com/airwallex/risk/RiskContext.kt
+++ b/RiskSdk/src/main/java/com/airwallex/risk/RiskContext.kt
@@ -22,7 +22,7 @@ internal interface IRiskContext {
     fun createEvent(
         eventType: String,
         path: String? = null,
-        createdAtUtc: Instant = Instant.now()
+        createdAtUtc: Long = System.currentTimeMillis()
     ): Event
 }
 
@@ -72,7 +72,7 @@ internal class RiskContext(
     override fun createEvent(
         eventType: String,
         path: String?,
-        createdAtUtc: Instant
+        createdAtUtc: Long
     ): Event =
         Event(
             riskContext = this,

--- a/RiskSdk/src/test/java/com/airwallex/risk/EventManagerTest.kt
+++ b/RiskSdk/src/test/java/com/airwallex/risk/EventManagerTest.kt
@@ -6,7 +6,9 @@ import com.airwallex.risk.helpers.FakeAutomaticEventProvider
 import com.airwallex.risk.helpers.Fixtures
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -36,7 +38,7 @@ class EventManagerTest {
         val automaticEventProvider = FakeAutomaticEventProvider()
         val lifecycleOwner = TestLifecycleOwner()
 
-        coEvery { apiService.postEvents(any()) } returns EventResponse(message = "message")
+        coEvery { apiService.postEvents(any()) } just runs
 
         val eventManager = EventManager(
             repository = repository,

--- a/RiskSdk/src/test/java/com/airwallex/risk/EventTest.kt
+++ b/RiskSdk/src/test/java/com/airwallex/risk/EventTest.kt
@@ -32,7 +32,7 @@ class EventTest {
             dataCollector = dataCollector,
             eventType = eventType,
             path = path,
-            createdAtUtc = Instant.now()
+            createdAtUtc = 10
         )
 
         assertEquals(event.accountId, riskContext.accountId)

--- a/RiskSdk/src/test/java/com/airwallex/risk/helpers/FakeRiskContext.kt
+++ b/RiskSdk/src/test/java/com/airwallex/risk/helpers/FakeRiskContext.kt
@@ -28,7 +28,7 @@ internal class FakeRiskContext : IRiskContext {
         this.userId = userId
     }
 
-    override fun createEvent(eventType: String, path: String?, createdAtUtc: Instant): Event =
+    override fun createEvent(eventType: String, path: String?, createdAtUtc: Long): Event =
         Fixtures.createEvent(
             eventType = eventType,
             path = path,

--- a/RiskSdk/src/test/java/com/airwallex/risk/helpers/Fixtures.kt
+++ b/RiskSdk/src/test/java/com/airwallex/risk/helpers/Fixtures.kt
@@ -13,7 +13,7 @@ internal object Fixtures {
     fun createEvent(
         eventType: String,
         path: String? = null,
-        createdAtUtc: Instant = Instant.now(),
+        createdAtUtc: Long = System.currentTimeMillis(),
         accountId: String? = "account id",
         userId: String? = "user id",
         deviceId: UUID = UUID.randomUUID(),
@@ -52,7 +52,7 @@ internal object Fixtures {
             screen = Screen(
                 path = path
             ),
-            createdAtUtc = createdAtUtc.toEpochMilli()
+            createdAtUtc = createdAtUtc
         )
     )
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'com.airwallex.risk.sample'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.airwallex.risk.sample"
-        minSdk 26
-        targetSdk 33
+        minSdk 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
@@ -38,12 +38,12 @@ dependencies {
      api project(':RiskSdk')
 //    implementation "io.github.airwallex:RiskSdk:$rootProject.airwallexSdkVersion"
 
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.core:core-ktx:1.13.1'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Sample"


### PR DESCRIPTION
The `Ktor` implementation in the project has caused the issue `java.security.cert.CertificateException: Domain specific configurations require that hostname aware checkServerTrusted(X509Certificate[], String, String) is used` whenever `AndroidManifest.xml` refers to custom `network_security_config.xml`, which a number of customer apps will do. The issue is also reported [here](https://youtrack.jetbrains.com/issue/KTOR-2243#focus=Comments-27-6432443.0-0). And it's not compatible with SDK version 21, so we decide to replace it with more fundamental approach `java.net`.

This pr replaces:
- `Ktor` with `java.net.HttpURLConnection`
- `Instant` with `System.currentTimeMillis`
- `Locales` with `locale`

So that it's compatible with minSDK version 21 rather than 26. The reason of expanding the support versions is because PA SDK's minmum support version needs to stay 21 from customers' feedback to support maximum Android users on the market.

<img width="200" alt="Screenshot 2024-07-12 at 13 25 50" src="https://github.com/user-attachments/assets/6f7738d9-6d41-41b9-90a7-e73c755f8176"/>
<img width="200" alt="Screenshot 2024-07-12 at 13 22 58" src="https://github.com/user-attachments/assets/1c1d8b97-57fa-49f3-a63f-df8d4b376cfe"/>
