### PR TITLE
[APAM70] risk SDK not recording open events

### DIFF
--- a/RiskSdk/src/main/java/com/airwallex/risk/ApiService.kt
+++ b/RiskSdk/src/main/java/com/airwallex/risk/ApiService.kt
@@ -66,6 +66,9 @@ internal class ApiService(
                 if (connection.responseCode >= serverErrorCode) {
                     throw ServerException()
                 }
+                if (events.any { event -> event.event.type == Constants.installationEventName }) {
+                    riskContext.hasSentInstallationEvent = true
+                }
             } catch (e: IOException) {
                 Log.d(Constants.logTag, "HttpURLConnection output error: ${e.message}")
                 when (e) {


### PR DESCRIPTION
Fix the issue that the risk SDK does not post open events.