### PR TITLE
docs: add standardized event names for common scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,16 +189,7 @@ To ensure consistency across integrations, use these standardized event names fo
 
 **Example Implementation:**
 ```kotlin
-// Transaction events
-AirwallexRisk.log(event = "transaction_initiated", screen = "payment_form")
-
-// Card security events
-AirwallexRisk.log(event = "card_pin_viewed", screen = "card_details")
-AirwallexRisk.log(event = "card_cvc_viewed", screen = "card_details")
-
-// Profile events
-AirwallexRisk.log(event = "profile_phone_updated", screen = "profile_settings")
-AirwallexRisk.log(event = "profile_email_updated", screen = "profile_settings")
+AirwallexRisk.log(event = "transaction_initiated", screen = "YOUR_APP_SCREEN_NAME")
 ```
 
 #### Request header

--- a/README.md
+++ b/README.md
@@ -168,6 +168,39 @@ AirwallexRisk.log(
 )
 ```
 
+##### Standardized Event Names
+
+To ensure consistency across integrations, use these standardized event names for common scenarios:
+
+| **Section** | **Event Name** | **Description** | **When to Use** |
+|-------------|----------------|-----------------|-----------------|
+| **Transaction Events** |
+| | `transaction_initiated` | User starts a new transaction flow | When user begins any payment/transfer process, before entering details |
+| **Card Security Events** |
+| | `card_pin_viewed` | User accessed/viewed card PIN | When user successfully views their card PIN through app |
+| | `card_cvc_viewed` | User accessed/viewed card CVC/CVV | When user successfully views their card CVC/security code |
+| **Profile Update Events** |
+| | `profile_phone_updated` | User changed their phone number | When phone number change is successfully saved |
+| | `profile_email_updated` | User changed their email address | When email change is successfully saved |
+
+**Naming Convention:**
+- Format: `category_action` (lowercase, underscore-separated)
+- Tense: Past tense for completed actions (`viewed`, `updated`, `initiated`)
+
+**Example Implementation:**
+```kotlin
+// Transaction events
+AirwallexRisk.log(event = "transaction_initiated", screen = "payment_form")
+
+// Card security events
+AirwallexRisk.log(event = "card_pin_viewed", screen = "card_details")
+AirwallexRisk.log(event = "card_cvc_viewed", screen = "card_details")
+
+// Profile events
+AirwallexRisk.log(event = "profile_phone_updated", screen = "profile_settings")
+AirwallexRisk.log(event = "profile_email_updated", screen = "profile_settings")
+```
+
 #### Request header
 
 When your app sends a request to Airwallex, you must add the provided header into your request before sending. This will be slightly different depending on your networking library, so check the documentation describing how to add headers for the library you're using.


### PR DESCRIPTION
## Summary

Add standardized event naming documentation to improve consistency across customer integrations and enhance risk engine data analysis capabilities.

## Changes

### New Standardized Events Section
Added a comprehensive table with standardized event names for common user scenarios:

#### Transaction Events
- `transaction_initiated` - When user begins any payment/transfer process

#### Card Security Events
- `card_pin_viewed` - When user successfully views their card PIN
- `card_cvc_viewed` - When user successfully views their card CVC/security code

#### Profile Update Events
- `profile_phone_updated` - When phone number change is successfully saved  
- `profile_email_updated` - When email change is successfully saved

### Documentation Improvements
- Clear naming convention: `category_action` format (lowercase, underscore-separated)
- Consistent past tense for completed actions
- Detailed descriptions of when to use each event
- Code examples showing proper implementation with Kotlin syntax

## Benefits

- **Consistency**: All customers use the same event names for the same activities
- **Better Analytics**: Risk engine can easily aggregate and analyze patterns across platforms
- **Developer Experience**: Clear guidance prevents confusion and naming inconsistencies
- **Data Quality**: Standardized events improve signal quality for fraud detection

## Implementation

Developers can now use these standardized events instead of custom names:

```kotlin
// Before (inconsistent across customers)
AirwallexRisk.log(event = "user_login")       // Customer A
AirwallexRisk.log(event = "sign_in")          // Customer B  
AirwallexRisk.log(event = "LOGIN")            // Customer C

// After (standardized)
AirwallexRisk.log(event = "transaction_initiated", screen = "payment_form")
AirwallexRisk.log(event = "card_pin_viewed", screen = "card_details")
AirwallexRisk.log(event = "profile_phone_updated", screen = "profile_settings")
```

This change maintains backward compatibility while providing clear guidance for new integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)