### PR TITLE
[APAM-548] Add automatic account login/logout events for scale tenant

### DIFF
--- a/RiskSdk/src/main/java/com/airwallex/risk/AirwallexRiskInternal.kt
+++ b/RiskSdk/src/main/java/com/airwallex/risk/AirwallexRiskInternal.kt
@@ -21,18 +21,41 @@ internal class AirwallexRiskInternal internal constructor(
     }
 
     fun setUserId(userId: String?) {
-        riskContext.updateUserId(userId = userId)
-        val eventType = if (userId == null) {
-            Constants.userLogoutEventName
-        } else {
-            Constants.userLoginEventName
+        val existingUserId = riskContext.userId
+        // If same value, do nothing
+        if (userId == existingUserId) return
+        // Send logout event before context update if there's an existing user
+        if (existingUserId != null) {
+            val logoutEvent = riskContext.createEvent(eventType = Constants.userLogoutEventName)
+            eventManager.queue(logoutEvent)
         }
-        val event = riskContext.createEvent(eventType = eventType)
-        eventManager.queue(event)
+        riskContext.updateUserId(userId = userId)
+        // Send login event after update if there's a new user
+        if (userId != null) {
+            val loginEvent = riskContext.createEvent(eventType = Constants.userLoginEventName)
+            eventManager.queue(loginEvent)
+        }
     }
 
     fun setAccountId(accountId: String?) {
+        if (riskContext.tenant != Tenant.SCALE) {
+            riskContext.updateAccountId(accountId = accountId)
+            return
+        }
+        val existingAccountId = riskContext.accountId
+        // If same value, do nothing
+        if (accountId == existingAccountId) return
+        // Send logout event before context update if there's an existing account
+        if (existingAccountId != null) {
+            val logoutEvent = riskContext.createEvent(eventType = Constants.accountLogoutEventName)
+            eventManager.queue(logoutEvent)
+        }
         riskContext.updateAccountId(accountId = accountId)
+        // Send login event after update if there's a new account
+        if (accountId != null) {
+            val loginEvent = riskContext.createEvent(eventType = Constants.accountLoginEventName)
+            eventManager.queue(loginEvent)
+        }
     }
 
     fun log(eventType: String, screen: String?) {

--- a/RiskSdk/src/main/java/com/airwallex/risk/Constants.kt
+++ b/RiskSdk/src/main/java/com/airwallex/risk/Constants.kt
@@ -11,4 +11,6 @@ internal object Constants {
     const val installationEventName: String = "installation"
     const val userLoginEventName: String = "user_login"
     const val userLogoutEventName: String = "user_logout"
+    const val accountLoginEventName: String = "account_login"
+    const val accountLogoutEventName: String = "account_logout"
 }

--- a/RiskSdk/src/test/java/com/airwallex/risk/AirwallexRiskInternalTest.kt
+++ b/RiskSdk/src/test/java/com/airwallex/risk/AirwallexRiskInternalTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.Before
 import org.junit.Test
 import java.util.UUID
@@ -40,11 +41,12 @@ class AirwallexRiskInternalTest {
     }
 
     @Test
-    fun `test set user id`() {
+    fun `test set user id from null triggers login event only`() {
         val riskContext: RiskContext = mockk()
         every { riskContext.deviceId } returns UUID.randomUUID()
         every { riskContext.sessionId } returns UUID.randomUUID()
         every { riskContext.description() } returns "description"
+        every { riskContext.userId } returns null
         every { riskContext.updateUserId(any()) } returns mockk()
         every { riskContext.createEvent(any(), any(), any()) } returns mockk()
 
@@ -59,16 +61,18 @@ class AirwallexRiskInternalTest {
         val userId = "abcde"
         shared.setUserId(userId)
         verify { riskContext.updateUserId(userId) }
-        verify { riskContext.createEvent(Constants.userLoginEventName, null, any()) }
-        verify { eventManager.queue(any()) }
+        verify(exactly = 1) { riskContext.createEvent(Constants.userLoginEventName, null, any()) }
+        verify(exactly = 0) { riskContext.createEvent(Constants.userLogoutEventName, null, any()) }
+        verify(exactly = 1) { eventManager.queue(any()) }
     }
 
     @Test
-    fun `test set user id to null triggers logout event`() {
+    fun `test set user id to null from existing triggers logout event only`() {
         val riskContext: RiskContext = mockk()
         every { riskContext.deviceId } returns UUID.randomUUID()
         every { riskContext.sessionId } returns UUID.randomUUID()
         every { riskContext.description() } returns "description"
+        every { riskContext.userId } returns "existingUser"
         every { riskContext.updateUserId(any()) } returns mockk()
         every { riskContext.createEvent(any(), any(), any()) } returns mockk()
 
@@ -81,17 +85,169 @@ class AirwallexRiskInternalTest {
         )
 
         shared.setUserId(null)
-        verify { riskContext.updateUserId(null) }
         verify { riskContext.createEvent(Constants.userLogoutEventName, null, any()) }
-        verify { eventManager.queue(any()) }
+        verify { riskContext.updateUserId(null) }
+        verify(exactly = 0) { riskContext.createEvent(Constants.userLoginEventName, null, any()) }
+        verify(exactly = 1) { eventManager.queue(any()) }
     }
 
     @Test
-    fun `test set account id`() {
+    fun `test set user id switching users triggers logout then login`() {
         val riskContext: RiskContext = mockk()
         every { riskContext.deviceId } returns UUID.randomUUID()
         every { riskContext.sessionId } returns UUID.randomUUID()
         every { riskContext.description() } returns "description"
+        every { riskContext.userId } returns "existingUser"
+        every { riskContext.updateUserId(any()) } returns mockk()
+        every { riskContext.createEvent(any(), any(), any()) } returns mockk()
+
+        val eventManager: EventManager = mockk()
+        every { eventManager.queue(any()) } returns Unit
+
+        val shared = AirwallexRiskInternal(
+            riskContext = riskContext,
+            eventManager = eventManager
+        )
+
+        shared.setUserId("newUser")
+        verifyOrder {
+            riskContext.createEvent(Constants.userLogoutEventName, null, any())
+            eventManager.queue(any())
+            riskContext.updateUserId("newUser")
+            riskContext.createEvent(Constants.userLoginEventName, null, any())
+            eventManager.queue(any())
+        }
+    }
+
+    @Test
+    fun `test set user id to same value does nothing`() {
+        val riskContext: RiskContext = mockk()
+        every { riskContext.deviceId } returns UUID.randomUUID()
+        every { riskContext.sessionId } returns UUID.randomUUID()
+        every { riskContext.description() } returns "description"
+        every { riskContext.userId } returns "sameUser"
+
+        val eventManager: EventManager = mockk()
+
+        val shared = AirwallexRiskInternal(
+            riskContext = riskContext,
+            eventManager = eventManager
+        )
+
+        shared.setUserId("sameUser")
+        verify(exactly = 0) { riskContext.updateUserId(any()) }
+        verify(exactly = 0) { eventManager.queue(any()) }
+    }
+
+    @Test
+    fun `test set account id for scale tenant from null triggers login event`() {
+        val riskContext: RiskContext = mockk()
+        every { riskContext.deviceId } returns UUID.randomUUID()
+        every { riskContext.sessionId } returns UUID.randomUUID()
+        every { riskContext.description() } returns "description"
+        every { riskContext.tenant } returns Tenant.SCALE
+        every { riskContext.accountId } returns null
+        every { riskContext.updateAccountId(any()) } returns mockk()
+        every { riskContext.createEvent(any(), any(), any()) } returns mockk()
+
+        val eventManager: EventManager = mockk()
+        every { eventManager.queue(any()) } returns Unit
+
+        val shared = AirwallexRiskInternal(
+            riskContext = riskContext,
+            eventManager = eventManager
+        )
+
+        shared.setAccountId("newAccountId")
+        verify { riskContext.updateAccountId("newAccountId") }
+        verify(exactly = 1) { riskContext.createEvent(Constants.accountLoginEventName, null, any()) }
+        verify(exactly = 0) { riskContext.createEvent(Constants.accountLogoutEventName, null, any()) }
+        verify(exactly = 1) { eventManager.queue(any()) }
+    }
+
+    @Test
+    fun `test set account id for scale tenant to null triggers logout event`() {
+        val riskContext: RiskContext = mockk()
+        every { riskContext.deviceId } returns UUID.randomUUID()
+        every { riskContext.sessionId } returns UUID.randomUUID()
+        every { riskContext.description() } returns "description"
+        every { riskContext.tenant } returns Tenant.SCALE
+        every { riskContext.accountId } returns "existingAccount"
+        every { riskContext.updateAccountId(any()) } returns mockk()
+        every { riskContext.createEvent(any(), any(), any()) } returns mockk()
+
+        val eventManager: EventManager = mockk()
+        every { eventManager.queue(any()) } returns Unit
+
+        val shared = AirwallexRiskInternal(
+            riskContext = riskContext,
+            eventManager = eventManager
+        )
+
+        shared.setAccountId(null)
+        verify { riskContext.createEvent(Constants.accountLogoutEventName, null, any()) }
+        verify { riskContext.updateAccountId(null) }
+        verify(exactly = 0) { riskContext.createEvent(Constants.accountLoginEventName, null, any()) }
+        verify(exactly = 1) { eventManager.queue(any()) }
+    }
+
+    @Test
+    fun `test set account id for scale tenant switching accounts triggers logout then login`() {
+        val riskContext: RiskContext = mockk()
+        every { riskContext.deviceId } returns UUID.randomUUID()
+        every { riskContext.sessionId } returns UUID.randomUUID()
+        every { riskContext.description() } returns "description"
+        every { riskContext.tenant } returns Tenant.SCALE
+        every { riskContext.accountId } returns "existingAccount"
+        every { riskContext.updateAccountId(any()) } returns mockk()
+        every { riskContext.createEvent(any(), any(), any()) } returns mockk()
+
+        val eventManager: EventManager = mockk()
+        every { eventManager.queue(any()) } returns Unit
+
+        val shared = AirwallexRiskInternal(
+            riskContext = riskContext,
+            eventManager = eventManager
+        )
+
+        shared.setAccountId("newAccountId")
+        verifyOrder {
+            riskContext.createEvent(Constants.accountLogoutEventName, null, any())
+            eventManager.queue(any())
+            riskContext.updateAccountId("newAccountId")
+            riskContext.createEvent(Constants.accountLoginEventName, null, any())
+            eventManager.queue(any())
+        }
+    }
+
+    @Test
+    fun `test set account id for scale tenant to same value does nothing`() {
+        val riskContext: RiskContext = mockk()
+        every { riskContext.deviceId } returns UUID.randomUUID()
+        every { riskContext.sessionId } returns UUID.randomUUID()
+        every { riskContext.description() } returns "description"
+        every { riskContext.tenant } returns Tenant.SCALE
+        every { riskContext.accountId } returns "sameAccount"
+
+        val eventManager: EventManager = mockk()
+
+        val shared = AirwallexRiskInternal(
+            riskContext = riskContext,
+            eventManager = eventManager
+        )
+
+        shared.setAccountId("sameAccount")
+        verify(exactly = 0) { riskContext.updateAccountId(any()) }
+        verify(exactly = 0) { eventManager.queue(any()) }
+    }
+
+    @Test
+    fun `test set account id for non-scale tenant does not trigger events`() {
+        val riskContext: RiskContext = mockk()
+        every { riskContext.deviceId } returns UUID.randomUUID()
+        every { riskContext.sessionId } returns UUID.randomUUID()
+        every { riskContext.description() } returns "description"
+        every { riskContext.tenant } returns Tenant.AIRWALLEX_MOBILE
         every { riskContext.updateAccountId(any()) } returns mockk()
 
         val eventManager: EventManager = mockk()
@@ -101,9 +257,34 @@ class AirwallexRiskInternalTest {
             eventManager = eventManager
         )
 
-        val accountId = "abcde"
-        shared.setAccountId(accountId)
-        verify { riskContext.updateAccountId(accountId) }
+        shared.setAccountId("newAccountId")
+        verify { riskContext.updateAccountId("newAccountId") }
+        verify(exactly = 0) { eventManager.queue(any()) }
+    }
+
+    @Test
+    fun `test set account id for PA tenant does not trigger events`() {
+        val riskContext: RiskContext = mockk()
+        every { riskContext.deviceId } returns UUID.randomUUID()
+        every { riskContext.sessionId } returns UUID.randomUUID()
+        every { riskContext.description() } returns "description"
+        every { riskContext.tenant } returns Tenant.PA
+        every { riskContext.updateAccountId(any()) } returns mockk()
+
+        val eventManager: EventManager = mockk()
+
+        val shared = AirwallexRiskInternal(
+            riskContext = riskContext,
+            eventManager = eventManager
+        )
+
+        shared.setAccountId("newAccountId")
+        verify { riskContext.updateAccountId("newAccountId") }
+        verify(exactly = 0) { eventManager.queue(any()) }
+
+        shared.setAccountId(null)
+        verify { riskContext.updateAccountId(null) }
+        verify(exactly = 0) { eventManager.queue(any()) }
     }
 
     @Test

--- a/RiskSdk/src/test/java/com/airwallex/risk/helpers/FakeRiskContext.kt
+++ b/RiskSdk/src/test/java/com/airwallex/risk/helpers/FakeRiskContext.kt
@@ -6,16 +6,19 @@ import com.airwallex.risk.IRiskContext
 import com.airwallex.risk.Tenant
 import java.util.UUID
 
-internal class FakeRiskContext : IRiskContext {
+internal class FakeRiskContext(
+    override val tenant: Tenant = Tenant.SCALE,
+    initialAccountId: String? = null,
+    initialUserId: String? = null
+) : IRiskContext {
 
-    override var userId: String? = null
-    override var accountId: String? = null
+    override var userId: String? = initialUserId
+    override var accountId: String? = initialAccountId
     override var hasSentInstallationEvent: Boolean = false
     override val userAgent: String = "user agent"
     override val sessionId: UUID = UUID.randomUUID()
     override val deviceId: UUID = UUID.randomUUID()
     override val environment: Environment = Environment.STAGING
-    override val tenant: Tenant = Tenant.SCALE
 
     override fun description(): String = "description"
 


### PR DESCRIPTION
## Summary
- Add `account_login` and `account_logout` automatic events triggered when `accountID` is updated via `setAccountId()` for scale tenant users
- Update `setUserId()` with consistent event timing (logout before update, login after update)
- Events only triggered when value actually changes (skip if same value)
- Logout event only sent when there's an existing account/user (not nil)

## Test plan
- [x] Verify `setAccountId()` sends login event when setting non-null value from null
- [x] Verify `setAccountId()` sends logout + login events when switching accounts
- [x] Verify `setAccountId()` sends logout event when setting null from non-null
- [x] Verify `setAccountId()` sends no events when setting same value
- [x] Verify `setAccountId()` sends no events for non-scale tenants (AIRWALLEX_MOBILE, PA)
- [x] Verify `setUserId()` follows same pattern
- [x] Run unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)